### PR TITLE
[fix] モバイルアプリ: 日付ナビゲーション・画面間データ反映バグ修正

### DIFF
--- a/apps/mobile/app/history.tsx
+++ b/apps/mobile/app/history.tsx
@@ -9,6 +9,7 @@ import {
   RefreshControl,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import { useFocusEffect } from "expo-router";
 import { useAuth } from "../hooks/useAuth";
 import { useNutrition } from "../hooks/useNutrition";
 import { listRecords, deleteRecord } from "../lib/api-client";
@@ -34,11 +35,18 @@ function formatDateStr(dateStr: string): string {
 function addDays(dateStr: string, days: number): string {
   const d = new Date(dateStr + "T00:00:00");
   d.setDate(d.getDate() + days);
-  return d.toISOString().split("T")[0];
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 function getToday(): string {
-  return new Date().toISOString().split("T")[0];
+  const d = new Date();
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 function getStatusColor(status: NutritionStatus): string {
@@ -101,9 +109,11 @@ export default function HistoryScreen() {
     }
   }, [deviceId, selectedDate]);
 
-  useEffect(() => {
-    fetchRecords();
-  }, [fetchRecords]);
+  useFocusEffect(
+    useCallback(() => {
+      fetchRecords();
+    }, [fetchRecords])
+  );
 
   const onRefresh = async () => {
     setRefreshing(true);

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import {
   View,
   Text,
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   RefreshControl,
 } from "react-native";
+import { useFocusEffect } from "expo-router";
 import { useAuth } from "../hooks/useAuth";
 import { useNutrition } from "../hooks/useNutrition";
 import {
@@ -15,7 +16,11 @@ import {
 } from "../lib/types";
 
 function getToday(): string {
-  return new Date().toISOString().split("T")[0];
+  const d = new Date();
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 function formatDate(dateStr: string): string {
@@ -97,6 +102,12 @@ export default function HomeScreen() {
   const today = getToday();
   const { nutrition, isLoading, refetch } = useNutrition(deviceId, today);
   const [refreshing, setRefreshing] = useState(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      refetch();
+    }, [refetch])
+  );
 
   const onRefresh = async () => {
     setRefreshing(true);

--- a/apps/mobile/app/record.tsx
+++ b/apps/mobile/app/record.tsx
@@ -28,7 +28,11 @@ import {
 const MEAL_TYPES: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
 
 function getToday(): string {
-  return new Date().toISOString().split("T")[0];
+  const d = new Date();
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 export default function RecordScreen() {


### PR DESCRIPTION
## Summary
- 履歴画面の日付ナビゲーションが1日単位で正しく動作しないバグを修正 (closes #25)
- 記録した商品が履歴画面・ホーム画面に反映されないバグを修正 (closes #26)

## 根本原因
- **#25**: `toISOString()` がUTCで出力するため、JST環境で `toISOString().split("T")[0]` が正しいローカル日付を返さなかった
- **#26**: 各画面が `useEffect` でマウント時のみデータ取得しており、タブ切り替え時にリフェッチされなかった

## 修正内容
- `getToday()` / `addDays()` をローカル日付フォーマット（`getFullYear()`/`getMonth()`/`getDate()`）に変更
- `history.tsx` / `index.tsx` で `useEffect` → `useFocusEffect` に変更し、画面フォーカス時にデータ再取得

## 変更ファイル
- `apps/mobile/app/history.tsx`
- `apps/mobile/app/index.tsx`
- `apps/mobile/app/record.tsx`

## Test plan
- [x] 履歴画面で「＜」「＞」ボタンが1日ずつ正確に移動することを確認
- [ ] 記録画面で商品追加後、履歴画面に切り替えると記録が反映されていることを確認
- [ ] 記録画面で商品追加後、ホーム画面に切り替えると栄養バランスが更新されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)