### PR TITLE
[fix] Web版で食事記録が動作しない (#67)

### DIFF
--- a/apps/mobile/app/record.tsx
+++ b/apps/mobile/app/record.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   Alert,
+  Platform,
   FlatList,
   ActivityIndicator,
 } from "react-native";
@@ -84,32 +85,48 @@ export default function RecordScreen() {
   const handleRecord = async (product: Product) => {
     if (!deviceId) return;
 
-    Alert.alert(
-      "食事を記録",
-      `${product.name}を${MEAL_TYPE_LABELS[selectedMealType]}として記録しますか？`,
-      [
-        { text: "キャンセル", style: "cancel" },
-        {
-          text: "記録する",
-          onPress: async () => {
-            setIsRecording(true);
-            try {
-              const record = await createRecord(deviceId, {
-                productId: product.productId,
-                date: today,
-                mealType: selectedMealType,
-              });
-              setTodayRecords((prev) => [...prev, record]);
-              Alert.alert("記録完了", `${product.name}を記録しました。`);
-            } catch {
-              Alert.alert("エラー", "記録に失敗しました。");
-            } finally {
-              setIsRecording(false);
-            }
-          },
-        },
-      ]
-    );
+    const doRecord = async () => {
+      setIsRecording(true);
+      try {
+        const record = await createRecord(deviceId, {
+          productId: product.productId,
+          date: today,
+          mealType: selectedMealType,
+        });
+        setTodayRecords((prev) => [...prev, record]);
+        if (Platform.OS === "web") {
+          window.alert(`${product.name}を記録しました。`);
+        } else {
+          Alert.alert("記録完了", `${product.name}を記録しました。`);
+        }
+      } catch {
+        if (Platform.OS === "web") {
+          window.alert("記録に失敗しました。");
+        } else {
+          Alert.alert("エラー", "記録に失敗しました。");
+        }
+      } finally {
+        setIsRecording(false);
+      }
+    };
+
+    if (Platform.OS === "web") {
+      const confirmed = window.confirm(
+        `${product.name}を${MEAL_TYPE_LABELS[selectedMealType]}として記録しますか？`
+      );
+      if (confirmed) {
+        doRecord();
+      }
+    } else {
+      Alert.alert(
+        "食事を記録",
+        `${product.name}を${MEAL_TYPE_LABELS[selectedMealType]}として記録しますか？`,
+        [
+          { text: "キャンセル", style: "cancel" },
+          { text: "記録する", onPress: doRecord },
+        ]
+      );
+    }
   };
 
   const renderProductItem = ({ item }: { item: Product }) => (


### PR DESCRIPTION
## Summary
- Web版（Expo Web）で `Alert.alert()` の `onPress` コールバックが発火しない問題を修正
- `Platform.OS === "web"` の場合は `window.confirm()` / `window.alert()` を直接使用するように分岐
- ネイティブ側の動作は変更なし

## Test plan
- [ ] Web版で商品をタップ → 確認ダイアログが表示される
- [ ] 「OK」を押すと食事記録が作成される
- [ ] 「キャンセル」を押すと記録されない
- [ ] ネイティブ（iOS/Android）で従来通り動作すること
- [ ] `pnpm --filter mobile type-check` が通ること

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)