### PR TITLE
[fix] 本番API URLの設定修正 — 記録と履歴の整合性が取れない問題

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -9,8 +9,8 @@ const getApiUrl = (): string => {
   if (IS_DEV) {
     return "http://localhost:8080/v1";
   }
-  // Production: replace with API Gateway URL
-  return "https://api.example.com/v1";
+  // Production: AWS API Gateway
+  return "https://osjsexo43j.execute-api.us-east-1.amazonaws.com/prod/v1";
 };
 
 export default ({ config }: ConfigContext): ExpoConfig => ({


### PR DESCRIPTION
## Summary
- `app.config.ts` の本番API URLが `https://api.example.com/v1`（プレースホルダー）のままだった
- 全APIリクエストが失敗し、モックデータにフォールバックしていた
- 記録はメモリ上のstateにのみ保存され、履歴画面に遷移すると消えていた
- 正しいAPI Gateway URL `https://osjsexo43j.execute-api.us-east-1.amazonaws.com/prod/v1` に修正

## Test plan
- [x] Playwrightで記録→履歴の整合性を確認済み
- [ ] 記録画面で商品をタップ → 記録成功 → 履歴タブに反映される
- [ ] 栄養サマリーが記録に応じて更新される

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)