### PR TITLE
ホーム画面に健康カレンダーを追加

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -41,6 +41,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   plugins: ["expo-router"],
   extra: {
     apiUrl: getApiUrl(),
+    calendarStartedMonth: process.env.EXPO_PUBLIC_CALENDAR_STARTED_MONTH ?? "",
     cognitoUserPoolId: process.env.COGNITO_USER_POOL_ID ?? "",
     cognitoClientId: process.env.COGNITO_CLIENT_ID ?? "",
     cognitoRegion: process.env.COGNITO_REGION ?? "us-east-1",

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,29 +1,38 @@
-import { useEffect, useState, useCallback } from "react";
+﻿import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  View,
-  Text,
+  Modal,
+  RefreshControl,
   ScrollView,
   StyleSheet,
-  RefreshControl,
+  Text,
+  TouchableOpacity,
+  View,
 } from "react-native";
-import { useFocusEffect } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { useFocusEffect, useRouter } from "expo-router";
 import { useAuth } from "../hooks/useAuth";
 import { useNutrition } from "../hooks/useNutrition";
+import {
+  CalendarHealthTone,
+  useNutritionCalendar,
+} from "../hooks/useNutritionCalendar";
 import {
   NutrientStatus,
   NutritionStatus,
   STATUS_LABELS,
 } from "../lib/types";
-import { getToday } from "../lib/date";
+import {
+  addMonths,
+  formatDateKey,
+  getMonthKey,
+  parseDateKey,
+} from "../lib/date";
 
-const formatDate = (dateStr: string): string => {
-  const d = new Date(dateStr + "T00:00:00");
-  const year = d.getFullYear();
-  const month = d.getMonth() + 1;
-  const day = d.getDate();
-  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
-  const weekday = weekdays[d.getDay()];
-  return `${year}年${month}月${day}日（${weekday}）`;
+const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"];
+
+const formatFullDate = (dateStr: string): string => {
+  const d = parseDateKey(dateStr);
+  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日 (${WEEKDAYS[d.getDay()]})`;
 };
 
 const getStatusColor = (status: NutritionStatus): string => {
@@ -46,6 +55,37 @@ const getStatusBgColor = (status: NutritionStatus): string => {
     case "excessive":
       return "#FFEBEE";
   }
+};
+
+const HEALTH_TONE_META: Record<
+  CalendarHealthTone,
+  { label: string; color: string; backgroundColor: string }
+> = {
+  good: {
+    label: "良好",
+    color: "#1B5E20",
+    backgroundColor: "#E8F5E9",
+  },
+  warning: {
+    label: "やや注意",
+    color: "#E65100",
+    backgroundColor: "#FFF3E0",
+  },
+  bad: {
+    label: "要改善",
+    color: "#B71C1C",
+    backgroundColor: "#FFEBEE",
+  },
+  empty: {
+    label: "記録なし",
+    color: "#546E7A",
+    backgroundColor: "#ECEFF1",
+  },
+  unknown: {
+    label: "読込中",
+    color: "#546E7A",
+    backgroundColor: "#F5F5F5",
+  },
 };
 
 interface NutrientCardProps {
@@ -104,11 +144,42 @@ const getSummaryText = (
   return `${deficients.join("と")}が不足しています。おすすめ画面で補える商品をチェックしましょう。`;
 };
 
+const buildCalendarGrid = (month: string): string[] => {
+  const [year, monthIndex] = month.split("-").map(Number);
+  const firstDay = new Date(year, monthIndex - 1, 1);
+  const lastDay = new Date(year, monthIndex, 0);
+  const leading = firstDay.getDay();
+  const dates: string[] = [];
+
+  for (let i = 0; i < leading; i += 1) {
+    dates.push("");
+  }
+
+  for (let day = 1; day <= lastDay.getDate(); day += 1) {
+    dates.push(formatDateKey(new Date(year, monthIndex - 1, day)));
+  }
+
+  while (dates.length % 7 !== 0) {
+    dates.push("");
+  }
+
+  return dates;
+};
+
 const HomeScreen = () => {
+  const router = useRouter();
   const { deviceId } = useAuth();
-  const today = getToday();
-  const { nutrition, isLoading, refetch } = useNutrition(deviceId, today);
+  const [selectedDate, setSelectedDate] = useState(formatDateKey(new Date()));
+  const [calendarVisible, setCalendarVisible] = useState(false);
+  const [calendarMonth, setCalendarMonth] = useState(getMonthKey(selectedDate));
+  const selectedMonth = calendarMonth;
+  const { nutrition, isLoading, refetch } = useNutrition(deviceId, selectedDate);
+  const calendar = useNutritionCalendar(deviceId, selectedMonth);
   const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    setCalendarMonth(getMonthKey(selectedDate));
+  }, [selectedDate]);
 
   useFocusEffect(
     useCallback(() => {
@@ -118,62 +189,169 @@ const HomeScreen = () => {
 
   const onRefresh = async () => {
     setRefreshing(true);
-    refetch();
+    await Promise.all([calendar.refresh(), Promise.resolve(refetch())]);
     setRefreshing(false);
   };
 
+  const calendarGrid = useMemo(() => buildCalendarGrid(selectedMonth), [selectedMonth]);
+
   return (
-    <ScrollView
-      style={styles.container}
-      contentContainerStyle={styles.contentContainer}
-      refreshControl={
-        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-      }
-    >
-      {/* Date Header */}
-      <View style={styles.dateHeader}>
-        <Text style={styles.dateText}>{formatDate(today)}</Text>
-        <Text style={styles.dateSubText}>今日の栄養バランス</Text>
-      </View>
+    <>
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.contentContainer}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        }
+      >
+        <View style={styles.heroCard}>
+          <View style={styles.heroHeader}>
+            <Text style={styles.heroDateText}>{formatFullDate(selectedDate)}</Text>
+            <TouchableOpacity
+              style={styles.calendarButton}
+              onPress={() => setCalendarVisible(true)}
+            >
+              <Ionicons name="calendar-outline" size={22} color="#2E7D32" />
+            </TouchableOpacity>
+          </View>
+        </View>
 
-      {/* Nutrition Cards */}
-      {isLoading ? (
-        <View style={styles.loadingCard}>
-          <Text style={styles.loadingText}>データを読み込み中...</Text>
-        </View>
-      ) : nutrition ? (
-        <View style={styles.cardsContainer}>
-          <NutrientCard
-            label="カロリー"
-            unit="kcal"
-            data={nutrition.calories}
-          />
-          <NutrientCard
-            label="タンパク質"
-            unit="g"
-            data={nutrition.protein}
-          />
-          <NutrientCard label="脂質" unit="g" data={nutrition.fat} />
-          <NutrientCard label="炭水化物" unit="g" data={nutrition.carbs} />
-        </View>
-      ) : (
-        <View style={styles.loadingCard}>
-          <Text style={styles.loadingText}>
-            データがありません。食事を記録してみましょう。
-          </Text>
-        </View>
-      )}
+        {isLoading ? (
+          <View style={styles.loadingCard}>
+            <Text style={styles.loadingText}>データを読み込み中...</Text>
+          </View>
+        ) : nutrition ? (
+          <View style={styles.cardsContainer}>
+            <NutrientCard label="カロリー" unit="kcal" data={nutrition.calories} />
+            <NutrientCard label="たんぱく質" unit="g" data={nutrition.protein} />
+            <NutrientCard label="脂質" unit="g" data={nutrition.fat} />
+            <NutrientCard label="炭水化物" unit="g" data={nutrition.carbs} />
+          </View>
+        ) : (
+          <View style={styles.loadingCard}>
+            <Text style={styles.loadingText}>
+              この日のデータはありません。食事を記録すると状態を確認できます。
+            </Text>
+          </View>
+        )}
 
-      {/* Summary */}
-      {nutrition && (
-        <View style={styles.summaryCard}>
-          <Text style={styles.summaryTitle}>今日のまとめ</Text>
-          <Text style={styles.summaryText}>
-            {getSummaryText(nutrition.calories, nutrition.protein)}
-          </Text>
+        {nutrition && (
+          <View style={styles.summaryCard}>
+            <Text style={styles.summaryTitle}>この日のまとめ</Text>
+            <Text style={styles.summaryText}>
+              {getSummaryText(nutrition.calories, nutrition.protein)}
+            </Text>
+          </View>
+        )}
+      </ScrollView>
+
+      <Modal
+        visible={calendarVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setCalendarVisible(false)}
+      >
+        <View style={styles.modalBackdrop}>
+          <View style={styles.calendarModal}>
+            <View style={styles.modalHeader}>
+              <View style={styles.modalHeaderContent}>
+                <View style={styles.monthSwitchRow}>
+                  <TouchableOpacity
+                    style={styles.monthSwitchButton}
+                    onPress={() => setCalendarMonth(addMonths(calendarMonth, -1))}
+                  >
+                    <Ionicons name="chevron-back" size={18} color="#203124" />
+                  </TouchableOpacity>
+                  <Text style={styles.modalTitle}>
+                    {parseDateKey(`${selectedMonth}-01`).getFullYear()}年
+                    {parseDateKey(`${selectedMonth}-01`).getMonth() + 1}月
+                  </Text>
+                  <TouchableOpacity
+                    style={styles.monthSwitchButton}
+                    onPress={() => setCalendarMonth(addMonths(calendarMonth, 1))}
+                  >
+                    <Ionicons name="chevron-forward" size={18} color="#203124" />
+                  </TouchableOpacity>
+                </View>
+                <Text style={styles.modalSubtitle}>
+                  色付きドットで健康状態を確認できます
+                </Text>
+              </View>
+              <TouchableOpacity onPress={() => setCalendarVisible(false)}>
+                <Ionicons name="close" size={24} color="#333" />
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.weekdayRow}>
+              {WEEKDAYS.map((weekday) => (
+                <Text key={weekday} style={styles.weekdayLabel}>
+                  {weekday}
+                </Text>
+              ))}
+            </View>
+
+            <View style={styles.calendarGrid}>
+              {calendarGrid.map((date, index) => {
+                if (!date) {
+                  return <View key={`empty-${index}`} style={styles.calendarCell} />;
+                }
+
+                const day = calendar.getDay(date);
+                const tone = day?.tone ?? "unknown";
+                const isSelected = date === selectedDate;
+                const meta = HEALTH_TONE_META[tone];
+
+                return (
+                  <TouchableOpacity
+                    key={date}
+                    style={[
+                      styles.calendarCell,
+                      isSelected && styles.calendarCellActive,
+                    ]}
+                    onPress={() => {
+                      setCalendarVisible(false);
+                      setSelectedDate(date);
+                      router.push({ pathname: "/history", params: { date } });
+                    }}
+                  >
+                    <Text
+                      style={[
+                        styles.calendarDateLabel,
+                        isSelected && styles.calendarDateLabelActive,
+                      ]}
+                    >
+                      {parseDateKey(date).getDate()}
+                    </Text>
+                    <View
+                      style={[
+                        styles.calendarToneDot,
+                        { backgroundColor: meta.color },
+                      ]}
+                    />
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            <View style={styles.legendRow}>
+              {(["good", "warning", "bad", "empty"] as CalendarHealthTone[]).map(
+                (tone) => (
+                  <View key={tone} style={styles.legendItem}>
+                    <View
+                      style={[
+                        styles.legendDot,
+                        { backgroundColor: HEALTH_TONE_META[tone].color },
+                      ]}
+                    />
+                    <Text style={styles.legendText}>{HEALTH_TONE_META[tone].label}</Text>
+                  </View>
+                )
+              )}
+            </View>
+          </View>
         </View>
-      )}
-    </ScrollView>
+      </Modal>
+    </>
   );
 };
 
@@ -187,22 +365,40 @@ const styles = StyleSheet.create({
   contentContainer: {
     padding: 16,
     paddingBottom: 32,
+    gap: 16,
   },
-  dateHeader: {
-    marginBottom: 20,
+  heroCard: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    padding: 16,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 2,
   },
-  dateText: {
-    fontSize: 22,
-    fontWeight: "bold",
-    color: "#333",
+  heroHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
   },
-  dateSubText: {
-    fontSize: 14,
-    color: "#888",
-    marginTop: 4,
+  heroDateText: {
+    fontSize: 24,
+    fontWeight: "800",
+    color: "#203124",
+    flex: 1,
+    marginRight: 12,
   },
   cardsContainer: {
     gap: 12,
+  },
+  calendarButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: "#EDF6EE",
+    alignItems: "center",
+    justifyContent: "center",
   },
   nutrientCard: {
     backgroundColor: "#fff",
@@ -297,5 +493,112 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: "#333",
     lineHeight: 20,
+  },
+  modalBackdrop: {
+    flex: 1,
+    backgroundColor: "rgba(15, 23, 18, 0.35)",
+    justifyContent: "center",
+    padding: 20,
+  },
+  calendarModal: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 24,
+    padding: 18,
+  },
+  modalHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    marginBottom: 18,
+  },
+  modalHeaderContent: {
+    flex: 1,
+    marginRight: 12,
+  },
+  monthSwitchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 4,
+  },
+  monthSwitchButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: "#F2F5F2",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  monthSwitchButtonDisabled: {
+    backgroundColor: "#F5F5F5",
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: "800",
+    color: "#203124",
+  },
+  modalSubtitle: {
+    fontSize: 12,
+    color: "#607063",
+  },
+  weekdayRow: {
+    flexDirection: "row",
+    marginBottom: 8,
+  },
+  weekdayLabel: {
+    flex: 1,
+    textAlign: "center",
+    fontSize: 12,
+    fontWeight: "700",
+    color: "#708070",
+  },
+  calendarGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    marginBottom: 16,
+  },
+  calendarCell: {
+    width: "14.285%",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 10,
+    borderRadius: 14,
+    minHeight: 52,
+  },
+  calendarCellActive: {
+    backgroundColor: "#EEF7EF",
+  },
+  calendarDateLabel: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#324234",
+    marginBottom: 4,
+  },
+  calendarDateLabelActive: {
+    color: "#1B5E20",
+  },
+  calendarToneDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  legendRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 12,
+  },
+  legendItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  legendDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  legendText: {
+    fontSize: 12,
+    color: "#607063",
   },
 });

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,4 +1,5 @@
-﻿import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import {
   Modal,
   RefreshControl,
@@ -10,6 +11,7 @@ import {
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect, useRouter } from "expo-router";
+import Constants from "expo-constants";
 import { useAuth } from "../hooks/useAuth";
 import { useNutrition } from "../hooks/useNutrition";
 import {
@@ -29,6 +31,9 @@ import {
 } from "../lib/date";
 
 const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"];
+const CALENDAR_STARTED_MONTH_KEY = "@konbini_navi_calendar_started_month";
+const DEV_CALENDAR_STARTED_MONTH =
+  Constants.expoConfig?.extra?.calendarStartedMonth ?? "";
 
 const formatFullDate = (dateStr: string): string => {
   const d = parseDateKey(dateStr);
@@ -172,14 +177,35 @@ const HomeScreen = () => {
   const [selectedDate, setSelectedDate] = useState(formatDateKey(new Date()));
   const [calendarVisible, setCalendarVisible] = useState(false);
   const [calendarMonth, setCalendarMonth] = useState(getMonthKey(selectedDate));
+  const [startedMonth, setStartedMonth] = useState(getMonthKey(selectedDate));
   const selectedMonth = calendarMonth;
   const { nutrition, isLoading, refetch } = useNutrition(deviceId, selectedDate);
   const calendar = useNutritionCalendar(deviceId, selectedMonth);
   const [refreshing, setRefreshing] = useState(false);
+  const currentMonth = getMonthKey(formatDateKey(new Date()));
 
   useEffect(() => {
     setCalendarMonth(getMonthKey(selectedDate));
   }, [selectedDate]);
+
+  useEffect(() => {
+    const ensureStartedMonth = async () => {
+      const current = getMonthKey(formatDateKey(new Date()));
+      if (DEV_CALENDAR_STARTED_MONTH) {
+        setStartedMonth(DEV_CALENDAR_STARTED_MONTH);
+        return;
+      }
+      const stored = await AsyncStorage.getItem(CALENDAR_STARTED_MONTH_KEY);
+      if (stored) {
+        setStartedMonth(stored);
+        return;
+      }
+      await AsyncStorage.setItem(CALENDAR_STARTED_MONTH_KEY, current);
+      setStartedMonth(current);
+    };
+
+    void ensureStartedMonth();
+  }, []);
 
   useFocusEffect(
     useCallback(() => {
@@ -194,6 +220,8 @@ const HomeScreen = () => {
   };
 
   const calendarGrid = useMemo(() => buildCalendarGrid(selectedMonth), [selectedMonth]);
+  const canGoPrevMonth = calendarMonth > startedMonth;
+  const canGoNextMonth = calendarMonth < currentMonth;
 
   return (
     <>
@@ -257,20 +285,36 @@ const HomeScreen = () => {
               <View style={styles.modalHeaderContent}>
                 <View style={styles.monthSwitchRow}>
                   <TouchableOpacity
-                    style={styles.monthSwitchButton}
-                    onPress={() => setCalendarMonth(addMonths(calendarMonth, -1))}
+                    style={[
+                      styles.monthSwitchButton,
+                      !canGoPrevMonth && styles.monthSwitchButtonDisabled,
+                    ]}
+                    onPress={() => canGoPrevMonth && setCalendarMonth(addMonths(calendarMonth, -1))}
+                    disabled={!canGoPrevMonth}
                   >
-                    <Ionicons name="chevron-back" size={18} color="#203124" />
+                    <Ionicons
+                      name="chevron-back"
+                      size={18}
+                      color={canGoPrevMonth ? "#203124" : "#B0B8B1"}
+                    />
                   </TouchableOpacity>
                   <Text style={styles.modalTitle}>
                     {parseDateKey(`${selectedMonth}-01`).getFullYear()}年
                     {parseDateKey(`${selectedMonth}-01`).getMonth() + 1}月
                   </Text>
                   <TouchableOpacity
-                    style={styles.monthSwitchButton}
-                    onPress={() => setCalendarMonth(addMonths(calendarMonth, 1))}
+                    style={[
+                      styles.monthSwitchButton,
+                      !canGoNextMonth && styles.monthSwitchButtonDisabled,
+                    ]}
+                    onPress={() => canGoNextMonth && setCalendarMonth(addMonths(calendarMonth, 1))}
+                    disabled={!canGoNextMonth}
                   >
-                    <Ionicons name="chevron-forward" size={18} color="#203124" />
+                    <Ionicons
+                      name="chevron-forward"
+                      size={18}
+                      color={canGoNextMonth ? "#203124" : "#B0B8B1"}
+                    />
                   </TouchableOpacity>
                 </View>
                 <Text style={styles.modalSubtitle}>

--- a/apps/mobile/hooks/useNutritionCalendar.ts
+++ b/apps/mobile/hooks/useNutritionCalendar.ts
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { getNutrition, listRecords } from "../lib/api-client";
+import { NutritionSummary } from "../lib/types";
+import { getMonthDates, getToday } from "../lib/date";
+
+export type CalendarHealthTone =
+  | "good"
+  | "warning"
+  | "bad"
+  | "empty"
+  | "unknown";
+
+export interface NutritionCalendarDay {
+  date: string;
+  tone: CalendarHealthTone;
+  summary?: NutritionSummary;
+  hasRecord: boolean;
+  isFuture: boolean;
+}
+
+interface NutritionCalendarCache {
+  month: string;
+  updatedAt: string;
+  days: Record<
+    string,
+    {
+      tone: CalendarHealthTone;
+      hasRecord: boolean;
+      summary?: NutritionSummary;
+    }
+  >;
+}
+
+interface UseNutritionCalendarResult {
+  month: string;
+  days: NutritionCalendarDay[];
+  isLoading: boolean;
+  isRefreshing: boolean;
+  refresh: () => Promise<void>;
+  getDay: (date: string) => NutritionCalendarDay | undefined;
+}
+
+const getCacheKey = (userId: string, month: string): string =>
+  `@nutrition_calendar:${userId}:${month}`;
+
+const createDefaultDays = (month: string): NutritionCalendarDay[] => {
+  const today = getToday();
+  return getMonthDates(month).map((date) => ({
+    date,
+    tone: date > today ? "unknown" : "empty",
+    hasRecord: false,
+    isFuture: date > today,
+  }));
+};
+
+const getCalendarTone = (
+  summary: NutritionSummary | undefined,
+  hasRecord: boolean
+): CalendarHealthTone => {
+  if (!hasRecord) return "empty";
+  if (!summary) return "unknown";
+
+  const statuses = [
+    summary.calories.status,
+    summary.protein.status,
+    summary.fat.status,
+    summary.carbs.status,
+  ];
+  const deficientCount = statuses.filter((status) => status === "deficient").length;
+  const excessiveCount = statuses.filter((status) => status === "excessive").length;
+
+  if (excessiveCount >= 2 || deficientCount >= 3) return "bad";
+  if (excessiveCount >= 1 || deficientCount >= 2) return "warning";
+  return "good";
+};
+
+const mergeCacheDays = (
+  baseDays: NutritionCalendarDay[],
+  cache: NutritionCalendarCache | null
+): NutritionCalendarDay[] =>
+  baseDays.map((day) => {
+    const cached = cache?.days[day.date];
+    if (!cached) return day;
+    return {
+      ...day,
+      tone: cached.tone,
+      hasRecord: cached.hasRecord,
+      summary: cached.summary,
+    };
+  });
+
+export const useNutritionCalendar = (
+  userId: string | null,
+  month: string
+): UseNutritionCalendarResult => {
+  const [days, setDays] = useState<NutritionCalendarDay[]>(() =>
+    createDefaultDays(month)
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  useEffect(() => {
+    setDays(createDefaultDays(month));
+  }, [month]);
+
+  const refresh = useCallback(async () => {
+    if (!userId) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsRefreshing(true);
+    try {
+      const dates = getMonthDates(month).filter((date) => date <= getToday());
+      const fetchedDays = await Promise.all(
+        dates.map(async (date) => {
+          try {
+            const records = await listRecords(userId, date);
+            const hasRecord = records.length > 0;
+            if (!hasRecord) {
+              return {
+                date,
+                tone: "empty" as const,
+                hasRecord,
+                isFuture: false,
+              };
+            }
+
+            const summary = await getNutrition(userId, date);
+            return {
+              date,
+              tone: getCalendarTone(summary, true),
+              hasRecord: true,
+              summary,
+              isFuture: false,
+            };
+          } catch {
+            return {
+              date,
+              tone: "unknown" as const,
+              hasRecord: false,
+              isFuture: false,
+            };
+          }
+        })
+      );
+
+      const nextDays = createDefaultDays(month).map((day) => {
+        const fetched = fetchedDays.find((item) => item.date === day.date);
+        return fetched ? { ...day, ...fetched } : day;
+      });
+
+      setDays(nextDays);
+
+      const cache: NutritionCalendarCache = {
+        month,
+        updatedAt: new Date().toISOString(),
+        days: Object.fromEntries(
+          nextDays
+            .filter((day) => !day.isFuture)
+            .map((day) => [
+              day.date,
+              {
+                tone: day.tone,
+                hasRecord: day.hasRecord,
+                summary: day.summary,
+              },
+            ])
+        ),
+      };
+
+      await AsyncStorage.setItem(getCacheKey(userId, month), JSON.stringify(cache));
+    } finally {
+      setIsLoading(false);
+      setIsRefreshing(false);
+    }
+  }, [month, userId]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!userId) {
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        const cached = await AsyncStorage.getItem(getCacheKey(userId, month));
+        const parsed = cached ? (JSON.parse(cached) as NutritionCalendarCache) : null;
+        setDays(mergeCacheDays(createDefaultDays(month), parsed));
+      } finally {
+        setIsLoading(false);
+      }
+
+      await refresh();
+    };
+
+    void load();
+  }, [month, refresh, userId]);
+
+  return {
+    month,
+    days,
+    isLoading,
+    isRefreshing,
+    refresh,
+    getDay: (date: string) => days.find((day) => day.date === date),
+  };
+};


### PR DESCRIPTION
## 概要
- ホーム画面上部にカレンダーボタンを追加し、月単位で健康状態を見られるようにします
- カレンダーの日付を押すと、その日付の履歴画面へ移動できるようにします

## 変更内容
- pps/mobile/app/index.tsx
  - ホーム画面に日付表示とカレンダーボタンを追加
  - カレンダーモーダルを追加
  - カレンダーの日付押下で履歴画面に遷移する導線を追加
- pps/mobile/hooks/useNutritionCalendar.ts
  - 月ごとの健康状態を取得する hook を追加
  - 日ごとの状態を good / warning / bad / empty / unknown で扱うように整理
  - AsyncStorage を使った月単位キャッシュを追加

## 動作確認
- 
pm.cmd run type-check
- ホーム画面でカレンダーボタンから月カレンダーを開けること
- カレンダーの日付に健康状態の色ドットが出ること
- カレンダーの日付を押すと、その日付の履歴画面へ遷移すること

## 補足
- この PR はホームの健康カレンダー機能を分割した 2 本目です
- ベース PR: #126
- 後続 PR で開始月の制限と確認用の環境変数を追加します