### PR TITLE
[fix] 履歴ページの削除ボタンとサマリー更新の不具合修正

### DIFF
--- a/apps/mobile/app/history.tsx
+++ b/apps/mobile/app/history.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   Alert,
+  Platform,
   RefreshControl,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
@@ -85,7 +86,7 @@ const HistoryScreen = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
 
-  const { nutrition } = useNutrition(deviceId, selectedDate);
+  const { nutrition, refetch: refetchNutrition } = useNutrition(deviceId, selectedDate);
 
   const isToday = selectedDate === getToday();
 
@@ -105,7 +106,8 @@ const HistoryScreen = () => {
   useFocusEffect(
     useCallback(() => {
       fetchRecords();
-    }, [fetchRecords])
+      refetchNutrition();
+    }, [fetchRecords, refetchNutrition])
   );
 
   const onRefresh = async () => {
@@ -115,28 +117,40 @@ const HistoryScreen = () => {
   };
 
   const handleDelete = (record: MealRecord) => {
-    Alert.alert(
-      "記録を削除",
-      `${record.product.name}の記録を削除しますか？`,
-      [
-        { text: "キャンセル", style: "cancel" },
-        {
-          text: "削除",
-          style: "destructive",
-          onPress: async () => {
-            if (!deviceId) return;
-            try {
-              await deleteRecord(deviceId, record.recordId);
-              setRecords((prev) =>
-                prev.filter((r) => r.recordId !== record.recordId)
-              );
-            } catch {
-              Alert.alert("エラー", "削除に失敗しました。");
-            }
-          },
-        },
-      ]
-    );
+    const doDelete = async () => {
+      if (!deviceId) return;
+      try {
+        await deleteRecord(deviceId, record.recordId);
+        setRecords((prev) =>
+          prev.filter((r) => r.recordId !== record.recordId)
+        );
+        refetchNutrition();
+      } catch {
+        if (Platform.OS === "web") {
+          window.alert("削除に失敗しました。");
+        } else {
+          Alert.alert("エラー", "削除に失敗しました。");
+        }
+      }
+    };
+
+    if (Platform.OS === "web") {
+      const confirmed = window.confirm(
+        `${record.product.name}の記録を削除しますか？`
+      );
+      if (confirmed) {
+        doDelete();
+      }
+    } else {
+      Alert.alert(
+        "記録を削除",
+        `${record.product.name}の記録を削除しますか？`,
+        [
+          { text: "キャンセル", style: "cancel" },
+          { text: "削除", style: "destructive", onPress: doDelete },
+        ]
+      );
+    }
   };
 
   const goToPrevDay = () => setSelectedDate(addDays(selectedDate, -1));
@@ -231,6 +245,7 @@ const HistoryScreen = () => {
                   <TouchableOpacity
                     onPress={() => handleDelete(record)}
                     style={styles.deleteButton}
+                    testID="delete-record-button"
                   >
                     <Ionicons
                       name="trash-outline"

--- a/e2e/bug-history-delete.spec.ts
+++ b/e2e/bug-history-delete.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from "@playwright/test";
+import {
+  TEST_USER_ID,
+  getToday,
+  cleanRecords,
+  apiRequest,
+  waitForApp,
+} from "./helpers";
+
+/**
+ * Bug investigation: Delete button on history page does not work on web.
+ *
+ * Root cause: history.tsx used Alert.alert() from react-native, which is a
+ * no-op on web. The fix uses Platform.OS === "web" to call window.confirm()
+ * on web, falling back to Alert.alert() on native platforms.
+ *
+ * Additional note: React Native Web renders TouchableOpacity as a generic
+ * <div> without role="button". We added testID="delete-record-button" to
+ * reliably locate the delete button via data-testid.
+ */
+test.describe("Bug: History page delete button", () => {
+  const today = getToday();
+
+  test.beforeEach(async () => {
+    await cleanRecords(TEST_USER_ID, today);
+  });
+
+  test("delete button click triggers confirmation and removes record", async ({
+    page,
+  }) => {
+    // 1. Create a test record via API
+    const created = await apiRequest<{
+      recordId: string;
+      product: { name: string };
+    }>(`/users/${TEST_USER_ID}/records`, {
+      method: "POST",
+      body: JSON.stringify({
+        productId: "prod_001",
+        date: today,
+        mealType: "lunch",
+      }),
+    });
+    expect(created.recordId).toBeDefined();
+
+    // 2. Navigate to app and go to history tab
+    await page.goto("/", { waitUntil: "networkidle" });
+    await waitForApp(page);
+
+    await page.getByRole("tab", { name: "履歴" }).click();
+    await page.waitForTimeout(3000);
+
+    // Verify the record is visible
+    const recordName = "手巻おにぎり 鮭";
+    await expect(page.getByText(recordName)).toBeVisible({ timeout: 10000 });
+
+    // 3. Monitor network for DELETE calls
+    const deleteApiCalls: string[] = [];
+    page.on("request", (req) => {
+      if (req.method() === "DELETE") {
+        deleteApiCalls.push(req.url());
+      }
+    });
+
+    // 4. Set up dialog handler to accept the confirmation
+    let dialogAppeared = false;
+    let dialogMessage = "";
+    page.on("dialog", async (dialog) => {
+      dialogAppeared = true;
+      dialogMessage = dialog.message();
+      await dialog.accept();
+    });
+
+    // 5. Click the delete button via testID
+    const deleteBtn = page.getByTestId("delete-record-button").first();
+    await deleteBtn.click({ timeout: 5000 });
+
+    // 6. Wait for dialog and deletion to complete
+    await page.waitForTimeout(2000);
+
+    // 7. Verify the fix works
+    expect(dialogAppeared, "Confirmation dialog should appear on web").toBe(
+      true
+    );
+    expect(dialogMessage).toContain(recordName);
+    expect(deleteApiCalls.length).toBeGreaterThan(0);
+
+    // Record should no longer be visible
+    await expect(page.getByText(recordName)).not.toBeVisible({
+      timeout: 5000,
+    });
+
+    // Verify via API that the record is actually gone
+    const listRes = await apiRequest<{ records: { recordId: string }[] }>(
+      `/users/${TEST_USER_ID}/records?date=${today}`
+    );
+    const found = listRes.records.find(
+      (r) => r.recordId === created.recordId
+    );
+    expect(found).toBeUndefined();
+  });
+
+  test("cancel dialog does not delete record", async ({ page }) => {
+    // Create a test record
+    await apiRequest(`/users/${TEST_USER_ID}/records`, {
+      method: "POST",
+      body: JSON.stringify({
+        productId: "prod_001",
+        date: today,
+        mealType: "lunch",
+      }),
+    });
+
+    await page.goto("/", { waitUntil: "networkidle" });
+    await waitForApp(page);
+
+    await page.getByRole("tab", { name: "履歴" }).click();
+    await page.waitForTimeout(3000);
+
+    const recordName = "手巻おにぎり 鮭";
+    await expect(page.getByText(recordName)).toBeVisible({ timeout: 10000 });
+
+    // Dismiss (cancel) the dialog
+    page.on("dialog", async (dialog) => {
+      await dialog.dismiss();
+    });
+
+    const deleteApiCalls: string[] = [];
+    page.on("request", (req) => {
+      if (req.method() === "DELETE") deleteApiCalls.push(req.url());
+    });
+
+    // Click delete button
+    const deleteBtn = page.getByTestId("delete-record-button").first();
+    await deleteBtn.click({ timeout: 5000 });
+
+    await page.waitForTimeout(2000);
+
+    // Record should still be visible (cancel = no delete)
+    await expect(page.getByText(recordName)).toBeVisible();
+    expect(deleteApiCalls.length).toBe(0);
+  });
+
+  test("delete API works correctly (backend is not the problem)", async ({
+    request,
+  }) => {
+    // Create a record
+    const createRes = await request.post(
+      `http://localhost:8080/v1/users/${TEST_USER_ID}/records`,
+      {
+        data: {
+          productId: "prod_001",
+          date: today,
+          mealType: "lunch",
+        },
+      }
+    );
+    expect(createRes.ok()).toBeTruthy();
+    const created = await createRes.json();
+
+    // Delete via API directly
+    const deleteRes = await request.delete(
+      `http://localhost:8080/v1/users/${TEST_USER_ID}/records/${created.recordId}`
+    );
+    expect(deleteRes.status()).toBe(204);
+
+    // Verify deleted
+    const listRes = await request.get(
+      `http://localhost:8080/v1/users/${TEST_USER_ID}/records?date=${today}`
+    );
+    const body = await listRes.json();
+    const found = body.records.find(
+      (r: { recordId: string }) => r.recordId === created.recordId
+    );
+    expect(found).toBeUndefined();
+  });
+});

--- a/e2e/bug-history-summary.spec.ts
+++ b/e2e/bug-history-summary.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from "@playwright/test";
+import { TEST_USER_ID, getToday, cleanRecords, apiRequest, waitForApp } from "./helpers";
+
+test.describe("Bug: History page nutrition summary update", () => {
+  const today = getToday();
+
+  test.beforeEach(async () => {
+    await cleanRecords(TEST_USER_ID, today);
+  });
+
+  test("nutrition summary updates when navigating back to history", async ({ page, request }) => {
+    // Step 1: Create first record (手巻おにぎり 鮭: 183 cal)
+    await apiRequest(`/users/${TEST_USER_ID}/records`, {
+      method: "POST",
+      body: JSON.stringify({
+        productId: "prod_001",
+        date: today,
+        mealType: "breakfast",
+      }),
+    });
+
+    // Step 2: Navigate to history and read initial nutrition
+    await page.goto("/history", { waitUntil: "networkidle" });
+    await waitForApp(page);
+    await page.waitForTimeout(3000);
+
+    // Get the initial calorie text from the nutrition mini section
+    const calValue = page.locator("text=/\\d+kcal/").first();
+    await expect(calValue).toBeVisible({ timeout: 10000 });
+    const initialCalText = await calValue.textContent();
+
+    // Step 3: Add another record via API (幕の内弁当: 712 cal)
+    await apiRequest(`/users/${TEST_USER_ID}/records`, {
+      method: "POST",
+      body: JSON.stringify({
+        productId: "prod_003",
+        date: today,
+        mealType: "lunch",
+      }),
+    });
+
+    // Step 4: Navigate away (home) and back (history)
+    await page.goto("/", { waitUntil: "networkidle" });
+    await waitForApp(page);
+    await page.waitForTimeout(1000);
+    await page.goto("/history", { waitUntil: "networkidle" });
+    await waitForApp(page);
+    await page.waitForTimeout(3000);
+
+    // Step 5: Read updated nutrition
+    const updatedCalValue = page.locator("text=/\\d+kcal/").first();
+    await expect(updatedCalValue).toBeVisible({ timeout: 10000 });
+    const updatedCalText = await updatedCalValue.textContent();
+
+    // The calorie value should have increased (183 → 895)
+    const initialCal = parseInt(initialCalText?.replace(/[^\d]/g, "") ?? "0");
+    const updatedCal = parseInt(updatedCalText?.replace(/[^\d]/g, "") ?? "0");
+    expect(updatedCal).toBeGreaterThan(initialCal);
+  });
+
+  test("nutrition summary updates after deleting a record", async ({ page, request }) => {
+    // Create two records
+    await apiRequest(`/users/${TEST_USER_ID}/records`, {
+      method: "POST",
+      body: JSON.stringify({
+        productId: "prod_001",
+        date: today,
+        mealType: "breakfast",
+      }),
+    });
+    const rec2 = await apiRequest<{ recordId: string }>(`/users/${TEST_USER_ID}/records`, {
+      method: "POST",
+      body: JSON.stringify({
+        productId: "prod_003",
+        date: today,
+        mealType: "lunch",
+      }),
+    });
+
+    // Navigate to history
+    await page.goto("/history", { waitUntil: "networkidle" });
+    await waitForApp(page);
+    await page.waitForTimeout(3000);
+
+    // Get initial calorie value
+    const calValue = page.locator("text=/\\d+kcal/").first();
+    await expect(calValue).toBeVisible({ timeout: 10000 });
+    const beforeDeleteText = await calValue.textContent();
+    const beforeDeleteCal = parseInt(beforeDeleteText?.replace(/[^\d]/g, "") ?? "0");
+
+    // Delete the second record via API
+    await apiRequest(`/users/${TEST_USER_ID}/records/${rec2.recordId}`, {
+      method: "DELETE",
+    });
+
+    // Navigate away and back to trigger refetch
+    await page.goto("/", { waitUntil: "networkidle" });
+    await waitForApp(page);
+    await page.waitForTimeout(1000);
+    await page.goto("/history", { waitUntil: "networkidle" });
+    await waitForApp(page);
+    await page.waitForTimeout(3000);
+
+    // Calorie value should have decreased
+    const afterDeleteValue = page.locator("text=/\\d+kcal/").first();
+    const afterDeleteText = await afterDeleteValue.textContent();
+    const afterDeleteCal = parseInt(afterDeleteText?.replace(/[^\d]/g, "") ?? "0");
+    expect(afterDeleteCal).toBeLessThan(beforeDeleteCal);
+  });
+});

--- a/e2e/bug-record-recommend.spec.ts
+++ b/e2e/bug-record-recommend.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/test";
+import { TEST_USER_ID, getToday, cleanRecords, apiRequest, waitForApp } from "./helpers";
+
+test.describe("Record page smoke tests", () => {
+  const today = getToday();
+
+  test.beforeEach(async () => {
+    await cleanRecords(TEST_USER_ID, today);
+  });
+
+  test("search filters products", async ({ page }) => {
+    await page.goto("/record", { waitUntil: "networkidle" });
+    await waitForApp(page);
+    await page.waitForTimeout(3000);
+
+    // Count initial products
+    const initialProducts = await page.locator("text=/kcal$/").count();
+    expect(initialProducts).toBeGreaterThan(0);
+
+    // Type search query
+    await page.getByPlaceholder("商品名で検索...").fill("サラダチキン");
+    await page.waitForTimeout(2000);
+
+    // Should have fewer results
+    const filteredProducts = await page.locator("text=/kcal$/").count();
+    expect(filteredProducts).toBeLessThan(initialProducts);
+    expect(filteredProducts).toBeGreaterThan(0);
+  });
+
+  test("meal type selector changes active state", async ({ page }) => {
+    await page.goto("/record", { waitUntil: "networkidle" });
+    await waitForApp(page);
+    await page.waitForTimeout(2000);
+
+    // Click "朝食" button
+    await page.getByText("朝食", { exact: true }).click();
+    await page.waitForTimeout(500);
+    // The button should be visually active (hard to check styles in RN web, but at least no error)
+
+    // Click "夕食" button
+    await page.getByText("夕食", { exact: true }).click();
+    await page.waitForTimeout(500);
+  });
+
+  test("recording a food updates today records section", async ({ page }) => {
+    await page.goto("/record", { waitUntil: "networkidle" });
+    await waitForApp(page);
+    await page.waitForTimeout(3000);
+
+    // Handle dialogs
+    page.on("dialog", async (dialog) => {
+      await dialog.accept();
+    });
+
+    // Click a product to record it
+    await page.getByText("手巻おにぎり 鮭").first().click();
+    await page.waitForTimeout(3000);
+
+    // "今日の記録" section should appear
+    await expect(page.getByText("今日の記録")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/1件/)).toBeVisible();
+  });
+
+  test("no console errors on record page", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" && !msg.text().includes("Slow network")) {
+        errors.push(msg.text());
+      }
+    });
+
+    await page.goto("/record", { waitUntil: "networkidle" });
+    await waitForApp(page);
+    await page.waitForTimeout(3000);
+
+    // Filter out known non-critical errors (deprecation warnings, etc)
+    const criticalErrors = errors.filter(
+      (e) => !e.includes("shadow") && !e.includes("pointerEvents") && !e.includes("Obsidian")
+    );
+    expect(criticalErrors).toHaveLength(0);
+  });
+});
+
+test.describe("Recommend page smoke tests", () => {
+  const today = getToday();
+
+  test.beforeEach(async () => {
+    await cleanRecords(TEST_USER_ID, today);
+  });
+
+  test("shows deficiency section when nutrition is deficient", async ({ page }) => {
+    // Record a small item so nutrition is deficient
+    await apiRequest(`/users/${TEST_USER_ID}/records`, {
+      method: "POST",
+      body: JSON.stringify({
+        productId: "prod_013",
+        date: today,
+        mealType: "breakfast",
+      }),
+    });
+
+    await page.goto("/recommend", { waitUntil: "networkidle" });
+    await waitForApp(page);
+    await page.waitForTimeout(3000);
+
+    // Should show deficiency section
+    await expect(page.getByText("不足している栄養素")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("recommendation cards show product details", async ({ page }) => {
+    // Record a small item
+    await apiRequest(`/users/${TEST_USER_ID}/records`, {
+      method: "POST",
+      body: JSON.stringify({
+        productId: "prod_013",
+        date: today,
+        mealType: "breakfast",
+      }),
+    });
+
+    await page.goto("/recommend", { waitUntil: "networkidle" });
+    await waitForApp(page);
+    await page.waitForTimeout(3000);
+
+    // Should have recommendation cards with price
+    await expect(page.locator("text=/\\d+円/").first()).toBeVisible({ timeout: 10000 });
+    // Should show reason text
+    await expect(page.locator("text=/不足しています/").first()).toBeVisible({ timeout: 10000 });
+    // Should show nutrient tags
+    await expect(page.locator("text=/を補える/").first()).toBeVisible({ timeout: 10000 });
+  });
+});


### PR DESCRIPTION
## Summary
- 履歴ページの削除ボタンがWeb上で動作しない不具合を修正（`Alert.alert` → `window.confirm` 分岐）
- 履歴ページの栄養サマリーがタブ切替時に更新されない不具合を修正（`useNutrition.refetch` を `useFocusEffect` と削除後に呼出）
- E2Eテスト11件追加（削除3件、サマリー更新2件、記録/おすすめスモーク6件）

## 変更内容
### 削除ボタン修正
`Alert.alert()` はReact Native Webでno-op。`Platform.OS === "web"` で `window.confirm()` に分岐するよう修正。

### サマリー更新修正
`history.tsx` で `useNutrition` の `refetch` を呼んでいなかった。`useFocusEffect` 内と `handleDelete` 後に `refetchNutrition()` を追加。

## Test plan
- [ ] `pnpm test:e2e` で29件のE2Eテスト全パス確認
- [ ] ブラウザで履歴ページの削除ボタンをクリック → 確認ダイアログ表示 → 削除成功
- [ ] 記録追加後、履歴ページに戻ると栄養サマリーが更新される
- [ ] 削除後、栄養サマリーが即座に更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)