### PR TITLE
ホーム画面に健康スコア表示を追加

### DIFF
--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,29 +1,31 @@
-import { useEffect, useState, useCallback } from "react";
-import {
-  View,
-  Text,
-  ScrollView,
-  StyleSheet,
-  RefreshControl,
-} from "react-native";
-import { useFocusEffect } from "expo-router";
+import { useCallback, useMemo, useState } from "react";
+import { useFocusEffect, useRouter } from "expo-router";
+import { RefreshControl, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useAuth } from "../hooks/useAuth";
+import { useHealthScoreStreak } from "../hooks/useHealthScoreStreak";
 import { useNutrition } from "../hooks/useNutrition";
+import { getToday, parseDateString } from "../lib/date";
+import {
+  calculateHealthScore,
+  getHealthScoreTone,
+} from "../lib/health-score";
 import {
   NutrientStatus,
   NutritionStatus,
   STATUS_LABELS,
 } from "../lib/types";
-import { getToday } from "../lib/date";
+
+const GAUGE_DOT_COUNT = 24;
+const STREAK_TARGET = 80;
 
 const formatDate = (dateStr: string): string => {
-  const d = new Date(dateStr + "T00:00:00");
+  const d = parseDateString(dateStr);
   const year = d.getFullYear();
   const month = d.getMonth() + 1;
   const day = d.getDate();
   const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
   const weekday = weekdays[d.getDay()];
-  return `${year}年${month}月${day}日（${weekday}）`;
+  return `${year}年${month}月${day}日 (${weekday})`;
 };
 
 const getStatusColor = (status: NutritionStatus): string => {
@@ -90,25 +92,159 @@ const NutrientCard = ({ label, unit, data }: NutrientCardProps) => {
   );
 };
 
+const ScoreGauge = ({
+  score,
+  label,
+  color,
+}: {
+  score: number;
+  label: string;
+  color: string;
+}) => {
+  const activeDots = Math.max(
+    0,
+    Math.min(GAUGE_DOT_COUNT, Math.round((score / 100) * GAUGE_DOT_COUNT))
+  );
+  const dots = Array.from({ length: GAUGE_DOT_COUNT }, (_, index) => {
+    const angle = (-90 + (360 / GAUGE_DOT_COUNT) * index) * (Math.PI / 180);
+    const radius = 58;
+    return {
+      index,
+      left: 68 + Math.cos(angle) * radius - 5,
+      top: 68 + Math.sin(angle) * radius - 5,
+      active: index < activeDots,
+    };
+  });
+
+  return (
+    <View style={styles.scorePanel}>
+      <View style={styles.scoreGauge}>
+        {dots.map((dot) => (
+          <View
+            key={dot.index}
+            style={[
+              styles.scoreDot,
+              {
+                left: dot.left,
+                top: dot.top,
+                backgroundColor: dot.active ? color : "#D7DEE6",
+              },
+            ]}
+          />
+        ))}
+        <View style={styles.scoreCenter}>
+          <Text style={[styles.scoreValue, { color }]}>{score}</Text>
+          <Text style={styles.scoreUnit}>/100</Text>
+        </View>
+      </View>
+      <Text style={styles.scoreCaption}>今日の健康スコア</Text>
+      <Text style={[styles.scoreLabel, { color }]}>{label}</Text>
+    </View>
+  );
+};
+
+const StreakCard = ({
+  streak,
+  isLoading,
+}: {
+  streak: number;
+  isLoading: boolean;
+}) => {
+  const isStarted = streak > 0;
+
+  return (
+    <View style={styles.streakCard}>
+      <Text style={styles.streakEyebrow}>STREAK</Text>
+      {isLoading ? (
+        <Text style={styles.streakValue}>計算中...</Text>
+      ) : isStarted ? (
+        <>
+          <Text style={styles.streakTitle}>{STREAK_TARGET}点以上の連続達成</Text>
+          <Text style={styles.streakValue}>{`${streak}日`}</Text>
+          <Text style={styles.streakHint}>
+            この調子で積み上げていきましょう。
+          </Text>
+        </>
+      ) : (
+        <>
+          <Text style={styles.streakTitle}>連続達成はこれから</Text>
+          <Text style={styles.streakValue}>{`今日${STREAK_TARGET}点で開始`}</Text>
+          <Text style={styles.streakHint}>
+            まずは今日、目標点を超えるところから始めましょう。
+          </Text>
+        </>
+      )}
+    </View>
+  );
+};
+
+const SummarySection = ({
+  summary,
+  onPressRecommend,
+}: {
+  summary: string;
+  onPressRecommend: () => void;
+}) => {
+  return (
+    <View style={styles.summaryCard}>
+      <Text style={styles.summaryTitle}>この日のまとめ</Text>
+      <Text style={styles.summaryText}>{summary}</Text>
+      <Text style={styles.summaryLink} onPress={onPressRecommend}>
+        おすすめ商品を見る
+      </Text>
+    </View>
+  );
+};
+
 const getSummaryText = (
   calories: NutrientStatus,
-  protein: NutrientStatus
+  protein: NutrientStatus,
+  fat: NutrientStatus,
+  carbs: NutrientStatus
 ): string => {
   const deficients: string[] = [];
-  if (calories.status === "deficient") deficients.push("カロリー");
-  if (protein.status === "deficient") deficients.push("タンパク質");
+  const excessive: string[] = [];
 
-  if (deficients.length === 0) {
-    return "栄養バランスが良好です。この調子で続けましょう！";
+  if (calories.status === "deficient") deficients.push("カロリー");
+  if (protein.status === "deficient") deficients.push("たんぱく質");
+  if (fat.status === "deficient") deficients.push("脂質");
+  if (carbs.status === "deficient") deficients.push("炭水化物");
+
+  if (calories.status === "excessive") excessive.push("カロリー");
+  if (fat.status === "excessive") excessive.push("脂質");
+  if (carbs.status === "excessive") excessive.push("炭水化物");
+
+  if (deficients.length === 0 && excessive.length === 0) {
+    return "栄養バランスが良好です。この調子で続けましょう。";
   }
-  return `${deficients.join("と")}が不足しています。おすすめ画面で補える商品をチェックしましょう。`;
+  if (deficients.length > 0 && excessive.length === 0) {
+    return `${deficients.join("・")}が不足気味です。おすすめ商品で補える食事を探してみましょう。`;
+  }
+  if (deficients.length === 0) {
+    return `${excessive.join("・")}が多めです。次の食事は軽めに整えるのがおすすめです。`;
+  }
+  return `${deficients.join("・")}の不足と${excessive.join("・")}の摂りすぎが見られます。おすすめ商品も参考にしながら整えましょう。`;
 };
 
 const HomeScreen = () => {
+  const router = useRouter();
   const { deviceId } = useAuth();
   const today = getToday();
   const { nutrition, isLoading, refetch } = useNutrition(deviceId, today);
+  const { streak, isLoading: isStreakLoading } = useHealthScoreStreak(
+    deviceId,
+    today,
+    STREAK_TARGET
+  );
   const [refreshing, setRefreshing] = useState(false);
+
+  const scoreResult = useMemo(
+    () => (nutrition ? calculateHealthScore(nutrition) : null),
+    [nutrition]
+  );
+  const scoreTone = scoreResult
+    ? getHealthScoreTone(scoreResult.total)
+    : null;
 
   useFocusEffect(
     useCallback(() => {
@@ -118,8 +254,12 @@ const HomeScreen = () => {
 
   const onRefresh = async () => {
     setRefreshing(true);
-    refetch();
+    await refetch();
     setRefreshing(false);
+  };
+
+  const goToRecommend = () => {
+    router.push("/recommend");
   };
 
   return (
@@ -130,46 +270,55 @@ const HomeScreen = () => {
         <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
       }
     >
-      {/* Date Header */}
       <View style={styles.dateHeader}>
         <Text style={styles.dateText}>{formatDate(today)}</Text>
-        <Text style={styles.dateSubText}>今日の栄養バランス</Text>
+        <Text style={styles.dateSubText}>
+          その日の栄養バランスを確認できます
+        </Text>
       </View>
 
-      {/* Nutrition Cards */}
       {isLoading ? (
         <View style={styles.loadingCard}>
           <Text style={styles.loadingText}>データを読み込み中...</Text>
         </View>
       ) : nutrition ? (
-        <View style={styles.cardsContainer}>
-          <NutrientCard
-            label="カロリー"
-            unit="kcal"
-            data={nutrition.calories}
-          />
-          <NutrientCard
-            label="タンパク質"
-            unit="g"
-            data={nutrition.protein}
-          />
-          <NutrientCard label="脂質" unit="g" data={nutrition.fat} />
-          <NutrientCard label="炭水化物" unit="g" data={nutrition.carbs} />
-        </View>
+        <>
+          {scoreResult && scoreTone ? (
+            <>
+              <View style={styles.heroRow}>
+                <ScoreGauge
+                  score={scoreResult.total}
+                  label={scoreTone.label}
+                  color={scoreTone.color}
+                />
+                <StreakCard
+                  streak={streak}
+                  isLoading={isStreakLoading}
+                />
+              </View>
+              <SummarySection
+                summary={getSummaryText(
+                  nutrition.calories,
+                  nutrition.protein,
+                  nutrition.fat,
+                  nutrition.carbs
+                )}
+                onPressRecommend={goToRecommend}
+              />
+            </>
+          ) : null}
+
+          <View style={styles.cardsContainer}>
+            <NutrientCard label="カロリー" unit="kcal" data={nutrition.calories} />
+            <NutrientCard label="たんぱく質" unit="g" data={nutrition.protein} />
+            <NutrientCard label="脂質" unit="g" data={nutrition.fat} />
+            <NutrientCard label="炭水化物" unit="g" data={nutrition.carbs} />
+          </View>
+        </>
       ) : (
         <View style={styles.loadingCard}>
           <Text style={styles.loadingText}>
-            データがありません。食事を記録してみましょう。
-          </Text>
-        </View>
-      )}
-
-      {/* Summary */}
-      {nutrition && (
-        <View style={styles.summaryCard}>
-          <Text style={styles.summaryTitle}>今日のまとめ</Text>
-          <Text style={styles.summaryText}>
-            {getSummaryText(nutrition.calories, nutrition.protein)}
+            この日のデータはありません。食事を記録してみましょう。
           </Text>
         </View>
       )}
@@ -187,9 +336,10 @@ const styles = StyleSheet.create({
   contentContainer: {
     padding: 16,
     paddingBottom: 32,
+    gap: 16,
   },
   dateHeader: {
-    marginBottom: 20,
+    gap: 4,
   },
   dateText: {
     fontSize: 22,
@@ -199,7 +349,123 @@ const styles = StyleSheet.create({
   dateSubText: {
     fontSize: 14,
     color: "#888",
+  },
+  heroRow: {
+    flexDirection: "row",
+    alignItems: "stretch",
+    gap: 12,
+    minHeight: 184,
+  },
+  streakCard: {
+    flex: 1,
+    backgroundColor: "#FFFFFF",
+    borderRadius: 18,
+    padding: 16,
+    justifyContent: "center",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  streakEyebrow: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 1,
+    color: "#7C8A97",
+  },
+  streakTitle: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#1F2933",
+    marginTop: 8,
+    lineHeight: 20,
+  },
+  streakValue: {
+    fontSize: 34,
+    fontWeight: "800",
+    color: "#1F2933",
+    marginTop: 12,
+  },
+  streakHint: {
+    fontSize: 12,
+    color: "#6B7785",
+    lineHeight: 18,
+    marginTop: 8,
+  },
+  scorePanel: {
+    width: 168,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  scoreGauge: {
+    width: 136,
+    height: 136,
+    position: "relative",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  scoreDot: {
+    position: "absolute",
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+  },
+  scoreCenter: {
+    width: 90,
+    height: 90,
+    borderRadius: 45,
+    backgroundColor: "#FFFFFF",
+    alignItems: "center",
+    justifyContent: "center",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 3,
+    elevation: 2,
+  },
+  scoreValue: {
+    fontSize: 34,
+    fontWeight: "800",
+    lineHeight: 38,
+  },
+  scoreUnit: {
+    fontSize: 12,
+    color: "#7A7A7A",
+    marginTop: 2,
+  },
+  scoreCaption: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#333",
+    marginTop: 12,
+  },
+  scoreLabel: {
+    fontSize: 12,
+    fontWeight: "600",
     marginTop: 4,
+  },
+  summaryCard: {
+    backgroundColor: "#E8F5E9",
+    borderRadius: 12,
+    padding: 16,
+  },
+  summaryTitle: {
+    fontSize: 16,
+    fontWeight: "bold",
+    color: "#2E7D32",
+    marginBottom: 8,
+  },
+  summaryText: {
+    fontSize: 14,
+    color: "#333",
+    lineHeight: 20,
+  },
+  summaryLink: {
+    marginTop: 12,
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#2E7D32",
   },
   cardsContainer: {
     gap: 12,
@@ -280,22 +546,6 @@ const styles = StyleSheet.create({
   loadingText: {
     fontSize: 14,
     color: "#888",
-  },
-  summaryCard: {
-    backgroundColor: "#E8F5E9",
-    borderRadius: 12,
-    padding: 16,
-    marginTop: 16,
-  },
-  summaryTitle: {
-    fontSize: 16,
-    fontWeight: "bold",
-    color: "#2E7D32",
-    marginBottom: 8,
-  },
-  summaryText: {
-    fontSize: 14,
-    color: "#333",
-    lineHeight: 20,
+    textAlign: "center",
   },
 });

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -167,8 +167,8 @@ const StreakCard = ({
         </>
       ) : (
         <>
-          <Text style={styles.streakTitle}>連続達成はこれから</Text>
-          <Text style={styles.streakValue}>{`今日${STREAK_TARGET}点で開始`}</Text>
+          <Text style={styles.streakTitle}>{STREAK_TARGET}点以上の連続達成</Text>
+          <Text style={styles.streakValue}>0日</Text>
           <Text style={styles.streakHint}>
             まずは今日、目標点を超えるところから始めましょう。
           </Text>

--- a/apps/mobile/hooks/useHealthScoreStreak.ts
+++ b/apps/mobile/hooks/useHealthScoreStreak.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from "react";
+import { getNutrition, listRecords } from "../lib/api-client";
+import { addDays } from "../lib/date";
+import { calculateHealthScore } from "../lib/health-score";
+
+interface UseHealthScoreStreakResult {
+  streak: number;
+  isLoading: boolean;
+}
+
+const DEFAULT_THRESHOLD = 80;
+const MAX_LOOKBACK_DAYS = 90;
+
+export function useHealthScoreStreak(
+  userId: string | null,
+  date: string,
+  threshold: number = DEFAULT_THRESHOLD
+): UseHealthScoreStreakResult {
+  const [streak, setStreak] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchStreak = useCallback(async () => {
+    if (!userId) {
+      setStreak(0);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      let nextStreak = 0;
+
+      for (let offset = 0; offset < MAX_LOOKBACK_DAYS; offset += 1) {
+        const targetDate = addDays(date, -offset);
+        const records = await listRecords(userId, targetDate);
+
+        if (records.length === 0) break;
+
+        const summary = await getNutrition(userId, targetDate);
+        const score = calculateHealthScore(summary).total;
+
+        if (score < threshold) break;
+
+        nextStreak += 1;
+      }
+
+      setStreak(nextStreak);
+    } catch {
+      setStreak(0);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [date, threshold, userId]);
+
+  useEffect(() => {
+    void fetchStreak();
+  }, [fetchStreak]);
+
+  return { streak, isLoading };
+}

--- a/apps/mobile/lib/date.ts
+++ b/apps/mobile/lib/date.ts
@@ -6,3 +6,17 @@ export const getToday = (): string => {
   const day = String(d.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 };
+
+export const parseDateString = (dateStr: string): Date => {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  return new Date(year, month - 1, day);
+};
+
+export const addDays = (dateStr: string, days: number): string => {
+  const date = parseDateString(dateStr);
+  date.setDate(date.getDate() + days);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};

--- a/apps/mobile/lib/health-score.ts
+++ b/apps/mobile/lib/health-score.ts
@@ -1,0 +1,93 @@
+import { NutritionSummary, NutrientStatus } from "./types";
+
+export interface HealthScoreBreakdown {
+  calories: number;
+  protein: number;
+  fat: number;
+  carbs: number;
+}
+
+export interface HealthScoreResult {
+  total: number;
+  breakdown: HealthScoreBreakdown;
+}
+
+const MAX_NUTRIENT_SCORE = 25;
+const OVERAGE_PENALTIES = {
+  calories: 10,
+  protein: 0,
+  fat: 10,
+  carbs: 7,
+} as const;
+
+function getBaseScore(data: NutrientStatus): number {
+  if (data.target <= 0) return 0;
+  const ratio = data.ratio ?? data.actual / data.target;
+  return Math.floor(MAX_NUTRIENT_SCORE * Math.min(ratio, 1));
+}
+
+function getOveragePenalty(
+  nutrient: keyof HealthScoreBreakdown,
+  data: NutrientStatus
+): number {
+  if (data.target <= 0 || data.actual <= data.target) return 0;
+  const overageRatio = (data.actual - data.target) / data.target;
+  return Math.floor(overageRatio * OVERAGE_PENALTIES[nutrient]);
+}
+
+function getNutrientScore(
+  nutrient: keyof HealthScoreBreakdown,
+  data: NutrientStatus
+): number {
+  const base = getBaseScore(data);
+  const penalty = getOveragePenalty(nutrient, data);
+  return Math.max(0, base - penalty);
+}
+
+export function calculateHealthScore(
+  summary: NutritionSummary
+): HealthScoreResult {
+  const breakdown: HealthScoreBreakdown = {
+    calories: getNutrientScore("calories", summary.calories),
+    protein: getNutrientScore("protein", summary.protein),
+    fat: getNutrientScore("fat", summary.fat),
+    carbs: getNutrientScore("carbs", summary.carbs),
+  };
+
+  return {
+    total:
+      breakdown.calories +
+      breakdown.protein +
+      breakdown.fat +
+      breakdown.carbs,
+    breakdown,
+  };
+}
+
+export function getHealthScoreTone(score: number): {
+  label: string;
+  color: string;
+  backgroundColor: string;
+} {
+  if (score >= 80) {
+    return {
+      label: "かなり良い状態",
+      color: "#1B5E20",
+      backgroundColor: "#E8F5E9",
+    };
+  }
+
+  if (score >= 60) {
+    return {
+      label: "あと少しで安定",
+      color: "#E65100",
+      backgroundColor: "#FFF3E0",
+    };
+  }
+
+  return {
+    label: "見直し余地あり",
+    color: "#B71C1C",
+    backgroundColor: "#FFEBEE",
+  };
+}


### PR DESCRIPTION
## 概要
- ホーム画面にその日の健康スコア表示を追加
- 80点以上の継続達成状況を表示
- この日のまとめからおすすめ画面へ移動できる導線を追加

## 変更内容
- 健康スコアを 100 点満点で計算するロジックを追加
- ホーム画面上部にスコア表示 UI を追加
- 継続達成日数を表示する hook を追加
- まとめ文をスコアの下、栄養カードの上に再配置

## 動作確認
- npm.cmd run type-check
- ホーム画面で健康スコアが表示されること
- 継続達成表示が出ること
- おすすめ画面への導線が動くこと
