### PR TITLE
[fix] Web版アイコンフォントが表示されない問題を修正

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -34,7 +34,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   web: {
     favicon: "./assets/favicon.png",
   },
-  plugins: ["expo-router"],
+  plugins: ["expo-router", "expo-font"],
   extra: {
     apiUrl: getApiUrl(),
     cognitoUserPoolId: process.env.COGNITO_USER_POOL_ID ?? "",

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,5 +1,6 @@
 import { Tabs, Slot, useRouter, useSegments } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
+import { useFonts } from "expo-font";
 import { StatusBar } from "expo-status-bar";
 import { AuthProvider, useAuth } from "../hooks/AuthContext";
 import { useEffect } from "react";
@@ -124,11 +125,23 @@ const RootLayoutInner = () => {
   );
 };
 
-const RootLayout = () => (
-  <AuthProvider>
-    <RootLayoutInner />
-  </AuthProvider>
-);
+const RootLayout = () => {
+  const [fontsLoaded] = useFonts(Ionicons.font);
+
+  if (!fontsLoaded) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#4CAF50" />
+      </View>
+    );
+  }
+
+  return (
+    <AuthProvider>
+      <RootLayoutInner />
+    </AuthProvider>
+  );
+};
 
 export default RootLayout;
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,6 +19,7 @@
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
     "expo-device": "~8.0.10",
+    "expo-font": "~14.0.11",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
     "expo-status-bar": "~3.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       expo-device:
         specifier: ~8.0.10
         version: 8.0.10(expo@54.0.33)
+      expo-font:
+        specifier: ~14.0.11
+        version: 14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-linking:
         specifier: ~8.0.11
         version: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
## Summary
- Web版でIoniconsアイコンが×ボックスになる問題を修正
- `expo-font`を追加し、`useFonts(Ionicons.font)`で明示的にフォントをロード
- `app.config.ts`に`expo-font`プラグインを追加

## Test plan
- [ ] Web版でタブバーのアイコン（ホーム、記録、履歴、おすすめ）が正しく表示される
- [ ] 履歴画面の左右矢印・削除アイコンが正しく表示される
- [ ] フォント読み込み中にローディング画面が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)