### PR TITLE
[fix] Web版で履歴の削除ボタンが動かない問題を修正

### DIFF
--- a/apps/mobile/app/history.tsx
+++ b/apps/mobile/app/history.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   Alert,
+  Platform,
   RefreshControl,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
@@ -115,28 +116,36 @@ const HistoryScreen = () => {
   };
 
   const handleDelete = (record: MealRecord) => {
-    Alert.alert(
-      "記録を削除",
-      `${record.product.name}の記録を削除しますか？`,
-      [
-        { text: "キャンセル", style: "cancel" },
-        {
-          text: "削除",
-          style: "destructive",
-          onPress: async () => {
-            if (!deviceId) return;
-            try {
-              await deleteRecord(deviceId, record.recordId);
-              setRecords((prev) =>
-                prev.filter((r) => r.recordId !== record.recordId)
-              );
-            } catch {
-              Alert.alert("エラー", "削除に失敗しました。");
-            }
-          },
-        },
-      ]
-    );
+    const doDelete = async () => {
+      if (!deviceId) return;
+      try {
+        await deleteRecord(deviceId, record.recordId);
+        setRecords((prev) =>
+          prev.filter((r) => r.recordId !== record.recordId)
+        );
+      } catch {
+        if (Platform.OS === "web") {
+          window.alert("削除に失敗しました。");
+        } else {
+          Alert.alert("エラー", "削除に失敗しました。");
+        }
+      }
+    };
+
+    if (Platform.OS === "web") {
+      if (window.confirm(`${record.product.name}の記録を削除しますか？`)) {
+        doDelete();
+      }
+    } else {
+      Alert.alert(
+        "記録を削除",
+        `${record.product.name}の記録を削除しますか？`,
+        [
+          { text: "キャンセル", style: "cancel" },
+          { text: "削除", style: "destructive", onPress: doDelete },
+        ]
+      );
+    }
   };
 
   const goToPrevDay = () => setSelectedDate(addDays(selectedDate, -1));


### PR DESCRIPTION
## Summary
- Web版で `Alert.alert` の確認ダイアログが動作せず、削除ボタンが反応しない問題を修正
- `Platform.OS === "web"` の場合は `window.confirm` / `window.alert` を使用するように分岐

## Test plan
- [ ] Web版で履歴画面の削除ボタン（ゴミ箱アイコン）をタップ → 確認ダイアログが表示される
- [ ] 「OK」で削除が実行され、一覧から消える
- [ ] 「キャンセル」で削除されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)